### PR TITLE
カレンダーのイベントをクリックしたときの挙動変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2108,6 +2108,13 @@
             "yallist": "^2.1.2"
           }
         },
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz?cache=0&sync_timestamp=1567937985360&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsource-map%2Fdownload%2Fsource-map-0.6.1.tgz",
@@ -9572,11 +9579,10 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npm.taobao.org/prettier/download/prettier-1.19.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fprettier%2Fdownload%2Fprettier-1.19.1.tgz",
-      "integrity": "sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=",
-      "dev": true,
-      "optional": true
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
     },
     "pretty-error": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.2.2",
     "node-sass": "^4.12.0",
+    "prettier": "^2.0.5",
     "sass-loader": "^8.0.2",
     "vue-template-compiler": "^2.6.11"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,42 +1,44 @@
 <template>
   <div id="app">
     <Header />
-    <router-view class="main"/>
+    <router-view class="main" />
     <Loading class="loading" />
     <Footer />
   </div>
 </template>
 
 <script>
-  import Header from "./components/Header"
-  import Footer from "./components/Footer"
-  import Loading from "./components/Loading"
-  export default {
-    components: {Header, Footer, Loading},
-  }
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import Loading from "./components/Loading";
+export default {
+  components: { Header, Footer, Loading },
+};
 </script>
 
 <style lang="scss">
-  html, body {
-    height: 100%;
-  }
+html,
+body {
+  height: 100%;
+}
 
-  #app {
-    height: 100%;
-    text-align: center;
-    color: #2c3e50;
-    font-family: Avenir, Helvetica, Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+#app {
+  height: 100%;
+  text-align: center;
+  color: #2c3e50;
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 
-    .main, .loading {
-      min-height: 80%;
-    }
+  .main,
+  .loading {
+    min-height: 80%;
   }
+}
 
-  .tooltip-inner {
-    @media (min-width: 1181px) {
-      max-width: 300px !important;
-    }
+.tooltip-inner {
+  @media (min-width: 1181px) {
+    max-width: 300px !important;
   }
+}
 </style>

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -14,31 +14,30 @@
 </template>
 
 <script>
-    import moment from 'moment'
-    export default {
-        name: "Event",
-        props: ['eventData'],
-        data() {
-            return {
-                summary: '',
-                short_summary: '',
-                max_summary: 15, //タイトルの文字数上限。一行に収まるように。
-                description: '',
-                max_description: 100, //説明文の文字数上限
-                date: '',
-                time: '',
-                html_link: '',
-            }
-        },
-        methods: {
-            setValue(val) {
-                this.summary = val.summary //tooltipで表示するように元のタイトルを取っておく
-                if (val.summary.length > this.max_summary) {
-                    this.short_summary = val.summary.substring(0,this.max_summary) + '...'
-                }
-                else {
-                    this.short_summary = val.summary
-                }
+import moment from "moment";
+export default {
+  name: "Event",
+  props: ["eventData"], //親コンポーネントで:event-data="~~~"で与えられるデータ
+  data() {
+    return {
+      summary: "",
+      short_summary: "",
+      max_summary: 15, //タイトルの文字数上限。一行に収まるように。
+      description: "",
+      max_description: 100, //説明文の文字数上限
+      date: "",
+      time: "",
+      html_link: "",
+    };
+  },
+  methods: {
+    setValue(val) {
+      this.summary = val.summary; //tooltipで表示するように元のタイトルを取っておく
+      if (val.summary.length > this.max_summary) {
+        this.short_summary = val.summary.substring(0, this.max_summary) + "...";
+      } else {
+        this.short_summary = val.summary;
+      }
 
                 this.description = val.description.substring(0,this.max_description)
 

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -1,16 +1,20 @@
 <template>
-    <div class="card event mb-5 mx-15px">
-        <p v-b-tooltip="this.summary" class="card-header bg-info font-weight-bold">
-            <a :href="this.html_link" class="text-light" target="_blank">{{this.short_summary}}</a>
-        </p>
-            <div class="card-body">
-            <b-list-group class="font-weight-normal text-left">
-                <small class="pb-3"><u>{{this.date}}{{this.time}}</u></small>
-    <!--            todo:URLをaタグで囲うようにする？セキュリティは？-->
-                <p class="mb-0">{{this.description}}</p>
-            </b-list-group>
-            </div>
+  <div class="event card border-info mb-5 mx-15px" :id="this.summary">
+    <p v-b-tooltip="this.summary" class="card-header bg-info font-weight-bold">
+      <a :href="this.html_link" class="text-light" target="_blank">{{
+        this.short_summary
+      }}</a>
+    </p>
+    <div class="card-body">
+      <b-list-group class="font-weight-normal text-left">
+        <small class="pb-3"
+          ><u>{{ this.date }}{{ this.time }}</u></small
+        >
+        <!--            todo:URLをaタグで囲うようにする？セキュリティは？-->
+        <p class="mb-0">{{ this.description }}</p>
+      </b-list-group>
     </div>
+  </div>
 </template>
 
 <script>
@@ -39,45 +43,45 @@ export default {
         this.short_summary = val.summary;
       }
 
-                this.description = val.description.substring(0,this.max_description)
+      this.description = val.description.substring(0, this.max_description);
 
-                if ('dateTime' in val.start) {
-                    let dateTime = val.start.dateTime
-                    this.date = this.getDate(dateTime)
-                    this.time = this.getTime(dateTime)
-                }
-                //終日イベントの場合
-                else {
-                    let date = val.start.date
-                    this.date = this.getDate(date)
-                }
+      if ("dateTime" in val.start) {
+        let dateTime = val.start.dateTime;
+        this.date = this.getDate(dateTime);
+        this.time = this.getTime(dateTime);
+      }
+      //終日イベントの場合
+      else {
+        let date = val.start.date;
+        this.date = this.getDate(date);
+      }
 
-                this.html_link = val.htmlLink
-            },
-            getDate(datetime) {
-                return moment(datetime).format('YYYY/MM/DD')
-            },
-            getTime(datetime) {
-                return moment(datetime).format('　HH:mm~')
-            },
-            // modifySummary(summary) {
-            //     //東北大のHPからとってきたデータに
-            // }
-        },
-        created() {
-            this.setValue(this.eventData)
-        }
-    }
+      this.html_link = val.htmlLink;
+    },
+    getDate(datetime) {
+      return moment(datetime).format("YYYY/MM/DD");
+    },
+    getTime(datetime) {
+      return moment(datetime).format("　HH:mm~");
+    },
+    // modifySummary(summary) {
+    //     //東北大のHPからとってきたデータに
+    // }
+  },
+  created() {
+    this.setValue(this.eventData);
+  },
+};
 </script>
 
 <style scoped lang="scss">
-    .event {
-        @media (min-width: 576px) {
-            flex: 0 45%;
-        }
+.event {
+  @media (min-width: 576px) {
+    flex: 0 45%;
+  }
 
-        @media (min-width: 918px) {
-            flex: 0 30%;
-        }
-    }
+  @media (min-width: 918px) {
+    flex: 0 30%;
+  }
+}
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -2,122 +2,121 @@
   <header class="mb-5 pt-4 pb-lg-4 pb-2">
     <b-navbar toggleable="lg" type="dark" class="justify-content-around">
       <h1 class="mb-0">東北大学セミナー情報</h1>
-      <b-navbar-toggle target="nav-collapse" class="border-0"/>
+      <b-navbar-toggle target="nav-collapse" class="border-0" />
       <b-collapse id="nav-collapse" class="flex-grow-0" is-nav>
         <router-link to="/">イベントカレンダー</router-link>
         <router-link to="/in-session">イベント詳細</router-link>
-        <auth/>
+        <auth />
       </b-collapse>
     </b-navbar>
   </header>
 </template>
 
 <script>
-  import Auth from './Auth'
+import Auth from "./Auth";
 
-  export default {
-    name: 'Header',
-    components: {Auth}
-  }
+export default {
+  name: "Header",
+  components: { Auth },
+};
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style lang="scss">
-  header {
-    background-color: #220c4c;
-    color: #fafafa;
+header {
+  background-color: #220c4c;
+  color: #fafafa;
 
-    h1 {
-      @media (max-width: 991px) {
-        padding-bottom: 10px;
-      }
+  h1 {
+    @media (max-width: 991px) {
+      padding-bottom: 10px;
+    }
 
-      @media (max-width: 576px) {
-        font-size: 26px;
+    @media (max-width: 576px) {
+      font-size: 26px;
+    }
+  }
+
+  .navbar-toggler {
+    @media (max-width: 991px) {
+      padding-top: 0;
+      padding-bottom: 10px;
+
+      &:focus {
+        outline: none;
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
       }
     }
 
-    .navbar-toggler {
+    .navbar-toggler-icon {
+      background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgb%28255, 255, 255%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") !important;
+    }
+  }
+
+  #nav-collapse {
+    @media (max-width: 991px) {
+      display: flex;
+      flex-wrap: wrap;
+      padding: 20px 15% 0 15%;
+      border-top: #aaa solid 1px;
+    }
+
+    @media (max-width: 900px) {
+      padding: 20px 14% 0 14%;
+    }
+
+    @media (max-width: 800px) {
+      padding: 20px 11% 0 11%;
+    }
+
+    @media (max-width: 700px) {
+      padding: 20px 10% 0 10%;
+    }
+
+    @media (max-width: 600px) {
+      padding: 20px 8% 0 8%;
+    }
+
+    @media (max-width: 500px) {
+      padding: 20px 11% 0 11%;
+    }
+
+    @media (max-width: 400px) {
+      padding: 20px 7% 0 7%;
+    }
+
+    > * {
       @media (max-width: 991px) {
-        padding-top: 0;
-        padding-bottom: 10px;
-
-        &:focus {
-          outline: none;
-          -webkit-tap-highlight-color: rgba(0,0,0,0);
-        }
-      }
-
-      .navbar-toggler-icon {
-        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgb%28255, 255, 255%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") !important;
+        flex: 0 0 100%;
+        text-align: right;
+        line-height: 2em;
+        font-size: 20px;
       }
     }
 
+    a {
+      font-weight: bold;
+      color: #fafafa;
 
-    #nav-collapse {
-      @media (max-width: 991px) {
-        display: flex;
-        flex-wrap: wrap;
-        padding: 20px 15% 0 15%;
-        border-top: #aaa solid 1px;
+      @media (min-width: 992px) {
+        margin-right: 40px;
       }
 
-      @media (max-width: 900px) {
-        padding: 20px 14% 0 14%;
-      }
+      &.router-link-exact-active {
+        color: rgb(198, 182, 15);
 
-      @media (max-width: 800px) {
-        padding: 20px 11% 0 11%;
-      }
-
-      @media (max-width: 700px) {
-        padding: 20px 10% 0 10%;
-      }
-
-      @media (max-width: 600px) {
-        padding: 20px 8% 0 8%;
-      }
-
-      @media (max-width: 500px) {
-        padding: 20px 11% 0 11%;
-      }
-
-      @media (max-width: 400px) {
-        padding: 20px 7% 0 7%;
-      }
-
-      > * {
-        @media (max-width: 991px) {
-          flex: 0 0 100%;
-          text-align: right;
-          line-height: 2.0em;
-          font-size: 20px;
+        &:hover {
+          text-decoration: none;
+          cursor: default;
         }
       }
 
-      a {
-        font-weight: bold;
-        color: #fafafa;
-
-        @media (min-width: 992px) {
-          margin-right: 40px;
-        }
-
-        &.router-link-exact-active {
-          color: rgb(198, 182, 15);
-
-          &:hover {
-            text-decoration: none;
-            cursor: default;
-          }
-        }
-
-        &:not(.router-link-exact-active) {
-          &:hover {
-            color: darken(#fafafa, 10%);
-          }
+      &:not(.router-link-exact-active) {
+        &:hover {
+          color: darken(#fafafa, 10%);
         }
       }
     }
   }
+}
 </style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,18 +1,18 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
-import firebase from 'firebase/app'
-import 'firebase/auth'
-import { setTitle } from '../mixins'
+import Vue from "vue";
+import VueRouter from "vue-router";
+import firebase from "firebase/app";
+import "firebase/auth";
+import { setTitle } from "../mixins";
 import store from "../store";
 
-Vue.use(VueRouter)
+Vue.use(VueRouter);
 
 const routes = [
   {
-    path: '/',
-    name: 'Calendar',
-    component: () => import('../views/Calendar'),
-    meta: {title: 'イベントカレンダー'}
+    path: "/",
+    name: "Calendar",
+    component: () => import("../views/Calendar"),
+    meta: { title: "イベントカレンダー" },
   },
   {
     path: '/in-session',
@@ -24,43 +24,43 @@ const routes = [
     meta: {title: '開催中のイベント'}
   },
   {
-    path: '/sign-in',
-    name: 'SignIn',
-    component: () => import('../views/SignIn'),
-    meta: {title: 'サインイン'}
+    path: "/sign-in",
+    name: "SignIn",
+    component: () => import("../views/SignIn"),
+    meta: { title: "サインイン" },
   },
   {
-    path: '*',
-    redirect: '/sign-in'
+    path: "*",
+    redirect: "/sign-in",
   },
-]
+];
 
 const router = new VueRouter({
-  mode: 'history',
+  mode: "history",
   base: process.env.BASE_URL,
-  routes
-})
+  routes,
+});
 
 //ログインしていなかったら'/sign-in'にリダイレクトする
 router.beforeResolve((to, from, next) => {
-  store.commit('onLoadingStateChanged', true);
+  store.commit("onLoadingStateChanged", true);
 
-  if (to.path === '/sign-in') {
-    setTitle(to.meta.title) //タイトルを動的に設定
-    next()
-    store.commit('onLoadingStateChanged', false);
+  if (to.path === "/sign-in") {
+    setTitle(to.meta.title); //タイトルを動的に設定
+    next();
+    store.commit("onLoadingStateChanged", false);
   } else {
-    firebase.auth().onAuthStateChanged(user => {
+    firebase.auth().onAuthStateChanged((user) => {
       if (user) {
-        setTitle(to.meta.title) //タイトルを動的に設定
-        next()
-        store.commit('onLoadingStateChanged', false);
+        setTitle(to.meta.title); //タイトルを動的に設定
+        next();
+        store.commit("onLoadingStateChanged", false);
       } else {
-        next({path: '/sign-in'})
-        store.commit('onLoadingStateChanged', false);
+        next({ path: "/sign-in" });
+        store.commit("onLoadingStateChanged", false);
       }
-    })
+    });
   }
-})
+});
 
-export default router
+export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,13 +15,11 @@ const routes = [
     meta: { title: "イベントカレンダー" },
   },
   {
-    path: '/in-session',
-    name: 'InSession',
-    // route level code-splitting
-    // this generates a separate chunk (about.[hash].js) for this route
-    // which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "about" */ '../views/InSession'),
-    meta: {title: '開催中のイベント'}
+    path: "/in-session/",
+    name: "InSession",
+    component: () => import("../views/InSession"),
+    meta: { title: "開催中のイベント" },
+    props: true, //InSessionコンポーネントにrouterからpropsを渡すことを許可
   },
   {
     path: "/sign-in",

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -13,20 +13,18 @@
 </template>
 
 <script>
-import FullCalendar from '@fullcalendar/vue'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import googleCalendarPlugin from '@fullcalendar/google-calendar'
+import FullCalendar from "@fullcalendar/vue";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import googleCalendarPlugin from "@fullcalendar/google-calendar";
 
 export default {
-  name: 'Calendar',
+  name: "Calendar",
   components: {
-    FullCalendar
+    FullCalendar,
   },
   data() {
     return {
-      calendarPlugins: [
-              dayGridPlugin, googleCalendarPlugin
-      ],
+      calendarPlugins: [dayGridPlugin, googleCalendarPlugin],
       googleCalendarApiKey: process.env.VUE_APP_CALENDAR_API_KEY,
       eventSources: [
         {
@@ -34,15 +32,15 @@ export default {
         },
         {
           //祝日を取得
-          googleCalendarId: 'japanese__ja@holiday.calendar.google.com',
-          className: 'is_holiday',
-          description: '祝日だよ',
-          success: function(events) {
-            let dayTops = document.getElementsByClassName('fc-day-top')
+          googleCalendarId: "japanese__ja@holiday.calendar.google.com",
+          className: "is_holiday",
+          description: "祝日だよ",
+          success: function (events) {
+            let dayTops = document.getElementsByClassName("fc-day-top");
 
-            events.forEach(event => {
-              for(let i=0; i < dayTops.length; i++) {
-                let dayTop = dayTops[i]
+            events.forEach((event) => {
+              for (let i = 0; i < dayTops.length; i++) {
+                let dayTop = dayTops[i];
                 if (event.start === dayTop.dataset.date) {
                   dayTop.classList.add('is_holiday')
                 }
@@ -59,44 +57,44 @@ export default {
 </script>
 
 <style lang="scss">
-  @import '~@fullcalendar/core/main.css';
-  @import '~@fullcalendar/daygrid/main.css';
+@import "~@fullcalendar/core/main.css";
+@import "~@fullcalendar/daygrid/main.css";
 
-  .calender-wrapper {
-    width: 90%;
-    max-width: 700px;
-    margin: 0 auto;
+.calender-wrapper {
+  width: 90%;
+  max-width: 700px;
+  margin: 0 auto;
 
-    .indent {
-      padding-left: 1em;
-      text-indent: -1em;
-    }
+  .indent {
+    padding-left: 1em;
+    text-indent: -1em;
+  }
 
-    .fc-scroller {
-      min-height: 384px;
+  .fc-scroller {
+    min-height: 384px;
 
-      .fc-content-skeleton {
-        thead {
-          .is_holiday {
-            .fc-day-number {
-              color: rgb(255, 84, 84);
-            }
-          }
-
-          .fc-sun {
-            .fc-day-number {
-              color: rgb(255, 84, 84);
-            }
+    .fc-content-skeleton {
+      thead {
+        .is_holiday {
+          .fc-day-number {
+            color: rgb(255, 84, 84);
           }
         }
 
-        tbody {
-          .is_holiday {
-            border-color: rgb(255, 84, 84);
-            background-color: rgb(255, 84, 84);
+        .fc-sun {
+          .fc-day-number {
+            color: rgb(255, 84, 84);
           }
+        }
+      }
+
+      tbody {
+        .is_holiday {
+          border-color: rgb(255, 84, 84);
+          background-color: rgb(255, 84, 84);
         }
       }
     }
   }
+}
 </style>

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,12 +1,15 @@
 <template>
   <div class="calendar">
     <div id="calendar" class="calender-wrapper">
-      <p class="text-left indent pb-3">※イベントをクリックしてGoogleカレンダーへ移動し、そこでイベントを複製すれば自分のカレンダーにイベントを追加できます。</p>
+      <p class="text-left indent pb-3">
+        ※イベントをクリックするとイベント詳細へ移動します。
+      </p>
       <FullCalendar
         default-view="dayGridMonth"
         :plugins="calendarPlugins"
         :google-calendar-api-key="googleCalendarApiKey"
         :event-sources="eventSources"
+        :locale="locale"
       />
     </div>
   </div>
@@ -42,18 +45,110 @@ export default {
               for (let i = 0; i < dayTops.length; i++) {
                 let dayTop = dayTops[i];
                 if (event.start === dayTop.dataset.date) {
-                  dayTop.classList.add('is_holiday')
+                  dayTop.classList.add("is_holiday");
                 }
               }
-            })
-          }
+            });
+          },
         },
-      ]
-    }
+      ],
+      locale: "ja", //カレンダーの表示言語
+      try_times: 0, //promiseの再起呼び出しを行った回数
+    };
   },
   methods: {
-  }
-}
+    promise: function (func, resolveFunc, rejectFunc, delay) {
+      const self = this;
+
+      new Promise((resolve, reject) => {
+        setTimeout(() => {
+          let result = func(); //成功したらtrueが返ってくる
+
+          //成功した場合はresolve
+          if (result) {
+            resolve();
+          }
+          //失敗した場合は再起実行
+          else {
+            //どれだけ待ってもイベントデータが取得できなければAPIの通信が上手くいっていない可能性が高いので、再帰処理を終了する。
+            if (self.try_times > 10) {
+              reject();
+              return;
+            }
+            this.try_times++;
+
+            //再帰呼び出し
+            self.promise(func, resolveFunc, rejectFunc, delay);
+          }
+        }, delay);
+      })
+        .then(() => {
+          resolveFunc();
+        })
+        .catch(() => {
+          rejectFunc();
+        });
+    },
+    //カレンダー内のイベントをクリックしたときの挙動を設定
+    //in-sessionページの該当するイベントの箇所に飛ばす
+    changeEventHref: function () {
+      const self = this;
+      const event_elements = self.$el.getElementsByClassName("fc-event");
+
+      //要素の取得に失敗したとき（まだfc-event要素がレンダーされていない。）
+      if (event_elements.length === 0) {
+        return false;
+      }
+
+      event_elements.forEach((element) => {
+        //祝日名をクリックしても画面遷移しないようにする
+        if (element.classList.contains("is_holiday")) {
+          element.href = "";
+          element.addEventListener("click", (e) => e.preventDefault());
+        }
+        //イベントのタイトルを取得してクリック時の画面遷移を設定する
+        else {
+          let title_element = element.getElementsByClassName("fc-title")[0];
+          let title = title_element.innerHTML;
+          element.href = `/in-session#${title}`;
+
+          element.addEventListener("click", (e) => {
+            e.preventDefault(); //vue-routerで制御するため
+            self.$router.push({
+              name: "InSession", //note: nameで遷移先を指定しないとparamsが渡せなかった.
+              params: { id: title },
+            });
+          });
+        }
+      });
+
+      return true;
+    },
+  },
+  mounted() {
+    //note: レンダリング直後だとカレンダーのイベントがまだDOMに存在していない（多分非同期で取ってきてる）ため、setTimeoutで調整
+    //note: 余裕をもって3秒でしているが、1秒くらいでも大丈夫なはず。
+    //note: 適当に時間を置いて実行するのではなく、イベントがレンダーされたときに実行するようにしたかったが難しかったので断念。
+    const self = this;
+    const preventClick = (e) => e.preventDefault();
+
+    //changeEventHrefが発火するまではクリックしてもリンク先に飛ばないようにする
+    this.$el.addEventListener("click", preventClick);
+    console.log("Add event listener.");
+
+    const removeClickListener = function () {
+      self.$el.removeEventListener("click", preventClick);
+      console.log("Removed event listener.");
+    };
+
+    const sayFailLoad = () => {
+      console.log("Failed to load event data");
+    };
+
+    //500msくらい時間を置いて実行すれば大丈夫そうだが、念のためpromiseメソッドで成功するまで再起実行するようにしている。
+    this.promise(this.changeEventHref, removeClickListener, sayFailLoad, 500);
+  },
+};
 </script>
 
 <style lang="scss">

--- a/src/views/InSession.vue
+++ b/src/views/InSession.vue
@@ -1,25 +1,39 @@
 <template>
   <div class="in-session px-lg-5 px-4">
-<!--    todo: 各学部のイベントページのリンクが張ってあるページを1つ用意してそっちに移行する-->
-<!--    <p class="mb-4 text-left">東北大学のイベントページは-->
-<!--      <a href="https://www.tohoku.ac.jp/japanese/2020/cate_event/" target="_blank">こちら</a>-->
-<!--    </p>-->
-    <div class="d-flex justify-content-between align-items-start  flex-column flex-sm-row">
-      <p class="text-left indent pb-3">※イベントのタイトル部分をクリックしてGoogleカレンダーへ移動し、そこでイベントを複製すれば自分のカレンダーにイベントを追加できます。</p>
+    <!--    todo: 各学部のイベントページのリンクが張ってあるページを1つ用意してそっちに移行する-->
+    <!--    <p class="mb-4 text-left">東北大学のイベントページは-->
+    <!--      <a href="https://www.tohoku.ac.jp/japanese/2020/cate_event/" target="_blank">こちら</a>-->
+    <!--    </p>-->
+    <div
+      class="d-flex justify-content-between align-items-start flex-column flex-sm-row"
+    >
+      <p class="text-left indent pb-3">
+        ※イベントのタイトル部分をクリックしてGoogleカレンダーへ移動し、そこでイベントを複製すれば自分のカレンダーにイベントを追加できます。
+      </p>
       <div>
-        <input class="mr-1 checkbox" type="checkbox" id="display_current" v-model="displayCurrent" />
+        <input
+          class="mr-1 checkbox"
+          type="checkbox"
+          id="display_current"
+          v-model="displayCurrent"
+        />
         <label for="display_current">開催中のイベントのみ表示</label>
       </div>
     </div>
     <b-card-group deck :class="this.displayCurrent ? 'show_current' : ''">
-      <Event :class="isCurrent(index)" :event-data="event" v-for="(event, index) in eventData" :key="event.summary"/>
+      <Event
+        :class="isCurrent(index)"
+        :event-data="event"
+        v-for="(event, index) in eventData"
+        :key="event.summary"
+      />
     </b-card-group>
   </div>
 </template>
 
 <script>
-  import Event from '../components/Event.vue'
-  import moment from 'moment'
+import Event from "../components/Event.vue";
+import moment from "moment";
 
   export default {
     name: 'InSession',
@@ -58,18 +72,18 @@
             let start
             let end
             //終日イベントの場合はdateTimeでなくてdateプロパティを保持してる
-            if ('dateTime' in item.start) {
-              start = this.getTimeInfo(item.start.dateTime)
-              end = this.getTimeInfo(item.end.dateTime)
+            if ("dateTime" in item.start) {
+              start = this.getTimeInfo(item.start.dateTime);
+              end = this.getTimeInfo(item.end.dateTime);
             } else {
-              start = this.getTimeInfo(item.start.date)
-              end = this.getTimeInfo(item.end.date)
+              start = this.getTimeInfo(item.start.date);
+              end = this.getTimeInfo(item.end.date);
             }
 
             if (this.isInSession(start, end)) {
-              this.inSessionEvents.push(i)
+              this.inSessionEvents.push(i);
             }
-            this.eventData.push(item)
+            this.eventData.push(item);
           }
         }).catch(e => {
           console.log(e)
@@ -92,15 +106,15 @@
           return true
         }
 
-        if (start.hour > now.hour || end.hour < now.hour) {
-          return false
-        }
-        if (start.hour === now.hour) {
-          return !(start.minute > now.minute)
-        }
-        if (end.hour === now.hour) {
-          return !(end.minute < now.minute)
-        }
+      if (start.hour > now.hour || end.hour < now.hour) {
+        return false;
+      }
+      if (start.hour === now.hour) {
+        return !(start.minute > now.minute);
+      }
+      if (end.hour === now.hour) {
+        return !(end.minute < now.minute);
+      }
 
         return true
       },
@@ -141,18 +155,18 @@
 </script>
 
 <style scoped lang="scss">
-  .indent {
-    padding-left: 1em;
-    text-indent: -1em;
-  }
+.indent {
+  padding-left: 1em;
+  text-indent: -1em;
+}
 
-  .checkbox {
-    transform: scale(1.3);
-  }
+.checkbox {
+  transform: scale(1.3);
+}
 
-  .show_current {
-    > :not(.current) {
-      display: none;
-    }
+.show_current {
+  > :not(.current) {
+    display: none;
   }
+}
 </style>

--- a/src/views/InSession.vue
+++ b/src/views/InSession.vue
@@ -35,42 +35,51 @@
 import Event from "../components/Event.vue";
 import moment from "moment";
 
-  export default {
-    name: 'InSession',
-    components: { Event },
-    data() {
-      return {
-        now: {}, //現在の時刻情報
-        eventData: [], //全てのイベントデータ
-        inSessionEvents: [], //開催中のイベントのインデックス
-        calendarUrl: 'https://www.googleapis.com/calendar/v3/calendars/',
-        calendarId: process.env.VUE_APP_CALENDAR_ID,
-        apiKey: process.env.VUE_APP_CALENDAR_API_KEY,
-        displayCurrent: false,
-      }
+export default {
+  name: "InSession",
+  components: { Event },
+  props: ["id"],
+  data() {
+    return {
+      now: {}, //現在の時刻情報
+      eventData: [], //全てのイベントデータ
+      inSessionEvents: [], //開催中のイベントのインデックス
+      calendarUrl: "https://www.googleapis.com/calendar/v3/calendars/",
+      calendarId: process.env.VUE_APP_CALENDAR_ID,
+      apiKey: process.env.VUE_APP_CALENDAR_API_KEY,
+      displayCurrent: false,
+      event_id: "",
+      try_times: 0,
+    };
+  },
+  methods: {
+    //google calendar apiを読み込む
+    load() {
+      // eslint-disable-next-line no-undef
+      gapi.load("client", this.init);
     },
-    methods: {
-      //google calendar apiを読み込む
-      load() {
-        // eslint-disable-next-line no-undef
-        gapi.load('client', this.init)
-      },
-      //google calendar apiを利用してイベント情報を取得する
-      init() {
-        // eslint-disable-next-line no-undef
-        gapi.client.init({
+    //google calendar apiを利用してイベント情報を取得する
+    init() {
+      // eslint-disable-next-line no-undef
+      gapi.client
+        .init({
           apiKey: this.apiKey,
-        }).then(() => {
+        })
+        .then(() => {
           // eslint-disable-next-line no-undef
           return gapi.client.request({
-            'path': this.calendarUrl + encodeURIComponent(this.calendarId) + '/events'
-          })
-        }).then(response => {
-          let items = response.result.items
-          for (let i=0; i < items.length; i++) {
-            let item = items[i]
-            let start
-            let end
+            path:
+              this.calendarUrl +
+              encodeURIComponent(this.calendarId) +
+              "/events",
+          });
+        })
+        .then((response) => {
+          let items = response.result.items;
+          for (let i = 0; i < items.length; i++) {
+            let item = items[i];
+            let start;
+            let end;
             //終日イベントの場合はdateTimeでなくてdateプロパティを保持してる
             if ("dateTime" in item.start) {
               start = this.getTimeInfo(item.start.dateTime);
@@ -85,26 +94,27 @@ import moment from "moment";
             }
             this.eventData.push(item);
           }
-        }).catch(e => {
-          console.log(e)
         })
-      },
-      //イベントの開始時刻と終了時刻から、そのイベントが現在開催中かどうかを判定する
-      isInSession(start, end) {
-        let now = this.now
-        if (start.year > now.year || end.year < now.year) {
-          return false
-        }
-        if (start.month > now.month || end.month < now.month) {
-          return false
-        }
-        if (start.day > now.day || end.day < now.day) {
-          return false
-        }
-        //終日イベントならここでtrueを返す
-        if (start.hour === 0 && end.hour === 0) {
-          return true
-        }
+        .catch((e) => {
+          console.log(e);
+        });
+    },
+    //イベントの開始時刻と終了時刻から、そのイベントが現在開催中かどうかを判定する
+    isInSession(start, end) {
+      let now = this.now;
+      if (start.year > now.year || end.year < now.year) {
+        return false;
+      }
+      if (start.month > now.month || end.month < now.month) {
+        return false;
+      }
+      if (start.day > now.day || end.day < now.day) {
+        return false;
+      }
+      //終日イベントならここでtrueを返す
+      if (start.hour === 0 && end.hour === 0) {
+        return true;
+      }
 
       if (start.hour > now.hour || end.hour < now.hour) {
         return false;
@@ -116,42 +126,83 @@ import moment from "moment";
         return !(end.minute < now.minute);
       }
 
-        return true
-      },
-      //世界標準時を引数に取り、年月日などをキーにしたオブジェクトにして返す
-      getTimeInfo(dateTime = null) {
-        if (dateTime === null) { //現在時刻の情報を取得する場合
-          return {
-            'year': parseInt(moment().format('YYYY')),
-            'month': parseInt(moment().format('MM')),
-            'day': parseInt(moment().format('DD')),
-            'hour': parseInt(moment().format('HH')),
-            'minute': parseInt(moment().format('mm')),
-          }
-        } else { //指定時刻の情報を取得する場合
-          return {
-            'year': parseInt(moment(dateTime).format('YYYY')),
-            'month': parseInt(moment(dateTime).format('MM')),
-            'day': parseInt(moment(dateTime).format('DD')),
-            'hour': parseInt(moment(dateTime).format('HH')),
-            'minute': parseInt(moment(dateTime).format('mm')),
-          }
-        }
-      },
-      isCurrent(index) {
-        if (this.inSessionEvents.includes(index)) {
-          return 'current'
-        }
-        else {
-          return ''
-        }
+      return true;
+    },
+    //世界標準時を引数に取り、年月日などをキーにしたオブジェクトにして返す
+    getTimeInfo(dateTime = null) {
+      if (dateTime === null) {
+        //現在時刻の情報を取得する場合
+        return {
+          year: parseInt(moment().format("YYYY")),
+          month: parseInt(moment().format("MM")),
+          day: parseInt(moment().format("DD")),
+          hour: parseInt(moment().format("HH")),
+          minute: parseInt(moment().format("mm")),
+        };
+      } else {
+        //指定時刻の情報を取得する場合
+        return {
+          year: parseInt(moment(dateTime).format("YYYY")),
+          month: parseInt(moment(dateTime).format("MM")),
+          day: parseInt(moment(dateTime).format("DD")),
+          hour: parseInt(moment(dateTime).format("HH")),
+          minute: parseInt(moment(dateTime).format("mm")),
+        };
       }
     },
-    created() {
-      this.now = this.getTimeInfo()
-      this.load()
+    //開催中のイベントかどうかを返す関数
+    isCurrent(index) {
+      if (this.inSessionEvents.includes(index)) {
+        return "current";
+      } else {
+        return "";
+      }
     },
-  }
+    //propsに渡されたidを持つ要素位置へページ内画面遷移する関数
+    scrollToEvent(id) {
+      //どれだけ待ってもイベントデータが取得できなければAPIの通信が上手くいっていない可能性が高いので、再帰処理を終了する。
+      if (this.try_times > 10) {
+        console.log("Failed to load event data...");
+        return;
+      }
+      this.try_times++;
+
+      const self = this;
+      setTimeout(function () {
+        const element = document.getElementById(id);
+
+        //要素が取得できるまで再帰的に実行する
+        if (element === null) {
+          self.scrollToEvent(id);
+        } else {
+          //ジャンプ先のイベントの枠線色変更
+          element.classList.remove("border-info");
+          element.classList.add("border-warning");
+
+          //ジャンプ先のイベントのヘッダー色変更
+          const el_event_header = element.getElementsByClassName(
+            "card-header"
+          )[0];
+          el_event_header.classList.remove("bg-info");
+          el_event_header.classList.add("bg-warning");
+
+          const element_height = element.offsetTop; //要素のページ内位置を取得
+          window.scrollTo(0, element_height - 100); //上部に少し余裕を持たせるため、要素位置-100の高さの位置に移動
+        }
+      }, 600); //600msくらいだと丁度イベントデータのレンダリングが終わっていが、念のためscrollToIdを再起実行している。
+    },
+  },
+  mounted() {
+    if (this.id !== undefined) {
+      //Calender APIからのイベントデータの取得が終わり、レンダリングされてから要素を探すようにsetTimeoutする。
+      this.scrollToEvent(this.id);
+    }
+  },
+  created() {
+    this.now = this.getTimeInfo();
+    this.load();
+  },
+};
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
- 元々はGoogleカレンダーのサイトに行くようになっていたので、univ-seminerのサイトのイベント詳細ページの該当する箇所に飛ぶようにした。
- google calenderからイベントを取得してレンダリングする処理が非同期だったので、ページを読み込んでから少し時間を置いてイベント要素を操作するようにした。
- WebStorm にPrettierを導入して自動フォーマっとするようにしたので、いくつかのファイルがフォーマッティングされている。