### PR TITLE
カレンダーからのページジャンプ処理の修正

### DIFF
--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -1,44 +1,46 @@
 <template>
-    <p v-if="isSignIn" @click="signOut" class="sign-out d-inline-block mb-0">サインアウト</p>
+  <p v-if="isSignIn" @click="signOut" class="sign-out d-inline-block mb-0">
+    サインアウト
+  </p>
 </template>
 
 <script>
-    import firebase from '../firebase'
+import firebase from "../firebase";
 
-    export default {
-        name: "Auth",
-        computed: {
-            isSignIn() {
-               return this.$store.getters.isSignIn
-            }
-        },
-        methods: {
-            signOut() {
-                firebase.logout()
-            }
-        },
-        created: () => {
-            firebase.onAuth()
-        },
-    }
+export default {
+  name: "Auth",
+  computed: {
+    isSignIn() {
+      return this.$store.getters.isSignIn;
+    },
+  },
+  methods: {
+    signOut() {
+      firebase.logout();
+    },
+  },
+  created: () => {
+    firebase.onAuth();
+  },
+};
 </script>
 
 <style scoped lang="scss">
 .sign-out {
-    cursor: pointer;
-    font-weight: bold;
+  cursor: pointer;
+  font-weight: bold;
 
-    @media (min-width: 992px) {
-        margin-left: 100px;
-    }
+  @media (min-width: 1171px) {
+    margin-left: 100px;
+  }
 
-    @media (max-width: 991px) {
-        margin-top: 20px;
-    }
+  @media (max-width: 991px) {
+    margin-top: 20px;
+  }
 
-    &:hover {
-        color: darken(#fafafa, 10%);
-        text-decoration: underline;
-    }
+  &:hover {
+    color: darken(#fafafa, 10%);
+    text-decoration: underline;
+  }
 }
 </style>

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="event card border-info mb-5 mx-15px" :id="this.summary">
+  <div class="event card border-info mb-5 mx-0" :id="this.summary">
     <p v-b-tooltip="this.summary" class="card-header bg-info font-weight-bold">
       <a :href="this.html_link" class="text-light" target="_blank">{{
         this.short_summary
@@ -36,12 +36,16 @@ export default {
   },
   methods: {
     setValue(val) {
-      this.summary = val.summary; //tooltipで表示するように元のタイトルを取っておく
+      //tooltipで表示するように元のタイトルを取っておく
+      let summary = val.summary;
+      summary = summary.replace(/^【Web(開催|配信)(\/(学内限定|PDP))?】/, "");
+      this.summary = summary;
+
       //タイトルがthis.max_summaryの値より長かったら途中で切る。
       if (val.summary.length > this.max_summary) {
-        this.short_summary = val.summary.substring(0, this.max_summary) + "...";
+        this.short_summary = summary.substring(0, this.max_summary) + "...";
       } else {
-        this.short_summary = val.summary;
+        this.short_summary = summary;
       }
 
       //文字数が150文字より多ければ切り取る。
@@ -71,9 +75,6 @@ export default {
     getTime(datetime) {
       return moment(datetime).format("　HH:mm~");
     },
-    // modifySummary(summary) {
-    //     //東北大のHPからとってきたデータに
-    // }
   },
   created() {
     this.setValue(this.eventData);
@@ -84,11 +85,13 @@ export default {
 <style scoped lang="scss">
 .event {
   @media (min-width: 576px) {
-    flex: 0 45%;
+    flex: 0 50%;
+    max-width: 45%;
   }
 
   @media (min-width: 918px) {
-    flex: 0 30%;
+    flex: 0 33%;
+    max-width: 30%;
   }
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -5,7 +5,8 @@
       <b-navbar-toggle target="nav-collapse" class="border-0" />
       <b-collapse id="nav-collapse" class="flex-grow-0" is-nav>
         <router-link to="/">イベントカレンダー</router-link>
-        <router-link to="/in-session">イベント詳細</router-link>
+        <router-link to="/events">イベント詳細</router-link>
+        <router-link to="/archive">過去のイベント</router-link>
         <auth />
       </b-collapse>
     </b-navbar>
@@ -99,6 +100,10 @@ header {
       color: #fafafa;
 
       @media (min-width: 992px) {
+        margin-right: 30px;
+      }
+
+      @media (min-width: 1171px) {
         margin-right: 40px;
       }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,11 +15,18 @@ const routes = [
     meta: { title: "イベントカレンダー" },
   },
   {
-    path: "/in-session/",
-    name: "InSession",
-    component: () => import("../views/InSession"),
+    path: "/events/",
+    name: "Events",
+    component: () => import("../views/Events"),
     meta: { title: "開催中のイベント" },
-    props: true, //InSessionコンポーネントにrouterからpropsを渡すことを許可
+    props: true, //Eventsコンポーネントにrouterからpropsを渡すことを許可
+  },
+  {
+    path: "/archive/",
+    name: "Archive",
+    component: () => import("../views/Archive"),
+    meta: { title: "過去のイベント" },
+    props: true, //Archiveコンポーネントにrouterからpropsを渡すことを許可
   },
   {
     path: "/sign-in",
@@ -29,7 +36,7 @@ const routes = [
   },
   {
     path: "*",
-    redirect: "/sign-in",
+    redirect: "/",
   },
 ];
 

--- a/src/views/Archive.vue
+++ b/src/views/Archive.vue
@@ -1,0 +1,11 @@
+<template>
+  <p>hoge</p>
+</template>
+
+<script>
+export default {
+  name: "Archive",
+};
+</script>
+
+<style scoped></style>

--- a/src/views/Events.vue
+++ b/src/views/Events.vue
@@ -1,16 +1,12 @@
 <template>
-  <div class="in-session px-lg-5 px-4">
-    <!--    todo: 各学部のイベントページのリンクが張ってあるページを1つ用意してそっちに移行する-->
-    <!--    <p class="mb-4 text-left">東北大学のイベントページは-->
-    <!--      <a href="https://www.tohoku.ac.jp/japanese/2020/cate_event/" target="_blank">こちら</a>-->
-    <!--    </p>-->
+  <div class="events px-lg-5 px-4">
     <div
-      class="d-flex justify-content-between align-items-start flex-column flex-sm-row"
+      class="d-flex justify-content-between align-items-start flex-column flex-lg-row"
     >
-      <p class="text-left indent pb-3">
+      <p class="text-left pb-3 description">
         ※イベントの<b>タイトル部分</b>をクリックしてGoogleカレンダーへ移動し、そこでイベントを複製すれば自分のカレンダーにイベントを追加できます。
       </p>
-      <div>
+      <div class="ml-lg-5">
         <input
           class="mr-1 checkbox"
           type="checkbox"
@@ -28,6 +24,14 @@
         :key="event.summary"
       />
     </b-card-group>
+    <p class="text-right font-weight-bold">
+      東北大学のイベントページは
+      <a
+        href="https://www.tohoku.ac.jp/japanese/2020/cate_event/"
+        target="_blank"
+        >こちら</a
+      >
+    </p>
   </div>
 </template>
 
@@ -36,7 +40,7 @@ import Event from "../components/Event.vue";
 import moment from "moment";
 
 export default {
-  name: "InSession",
+  name: "Events",
   components: { Event },
   props: ["id"],
   data() {
@@ -124,6 +128,7 @@ export default {
         });
     },
     //イベントの開始時刻と終了時刻を受け取り、イベントの開催状況（開催中・終わった  ・これから）を返す。
+    //note: カレンダーからの遷移を考慮して今日のイベントは全てnowにしてるが、そこは要検討。時分まで見る実装も残しておく。
     getEventTime(start, end) {
       let now = this.now;
 
@@ -143,20 +148,24 @@ export default {
       //既に終わったイベントの場合
       if (joinedEndYMD - joinedNowYMD < 0) return "past";
 
-      //全日イベントの場合は開始・終了時刻に0が入っている
-      if (start.hour === 0 && end.hour === 0) {
-        return "now";
-      }
+      // //note: 時分まで見る場合はこれは消す
+      // return "now";
 
-      //開始時間の時単位が同じ場合は分で判別
-      if (start.hour === now.hour) {
-        return start.minute > now.minute ? "future" : "now";
-      }
-
-      //終了時間の時単位が同じ場合は分で判別
-      if (end.hour === now.hour) {
-        return end.minute < now.minute ? "past" : "now";
-      }
+      //note: 時分まで見る実装
+      // //全日イベントの場合は開始・終了時刻に0が入っている
+      // if (start.hour === 0 && end.hour === 0) {
+      //   return "now";
+      // }
+      //
+      // //開始時間の時単位が同じ場合は分で判別
+      // if (start.hour === now.hour) {
+      //   return start.minute > now.minute ? "future" : "now";
+      // }
+      //
+      // //終了時間の時単位が同じ場合は分で判別
+      // if (end.hour === now.hour) {
+      //   return end.minute < now.minute ? "past" : "now";
+      // }
     },
     //年月日を受け取り、桁を考慮して合成する関数
     getJoinedYMD(year, month, day) {
@@ -240,7 +249,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.indent {
+.description {
+  flex: 1;
   padding-left: 1em;
   text-indent: -1em;
 }
@@ -253,5 +263,9 @@ export default {
   > :not(.current) {
     display: none;
   }
+}
+
+.card-deck {
+  justify-content: space-around;
 }
 </style>


### PR DESCRIPTION
- クリックされたイベントの開催日時によってジャンプする先のページを切り替えるようにした。過去のものなら新しく作った「過去のイベント」ページにジャンプする。
- コメントにも残してある通り今日の日付のものは全てイベント詳細ページに表示するようにしているが、ここは適宜変えてもいいかも。